### PR TITLE
Clean up cli output and README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ tests/data/*.gcm
 *.gcm
 discs/
 generated/
-
+*_generated/
 
 # Local database for title ids
 database/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ From the repo root:
 
 ```sh
 cmake -S . -B build
-cmake --build build --config Release -j 14
+cmake --build build --config Release
 ctest --test-dir build -C Release --output-on-failure
 ```
 
@@ -88,9 +88,9 @@ dolrecomp.exe --gamecube path\to\main.dol build
 Wii DOLs require a six-character title ID:
 
 ```sh
-dolrecomp.exe -j14 path\to\main.dol SUKE01 build
+dolrecomp.exe path\to\main.dol SUKE01 build
 
-./dolrecomp -j14 path/to/main.dol SUKE01 build
+./dolrecomp path/to/main.dol SUKE01 build
 ```
 
 ### REL Modules

--- a/README.md
+++ b/README.md
@@ -55,63 +55,94 @@ Set up the local title database if you want Wii title names in CLI output. Setup
 
 <sub>this was just a fun extra thing, just run in gamecube mode if you want to skip it</sub>
 
-
 ```sh
+# Windows
 dolrecomp.exe --setup
+
+# MacOS/Linux
+./dolrecomp --setup
 ```
 
-Wii DOLs require a six-character title ID:
-
-```sh
-dolrecomp.exe -j14 path\to\main.dol SUKE01 build
-```
-
+### Gamecube
 GameCube DOLs do not use a title ID:
 
 ```sh
 dolrecomp.exe --gamecube path\to\main.dol build
+
+./dolrecomp --gamecube path/to/main.dol build
 ```
+
+### Wii
+Wii DOLs require a six-character title ID:
+
+```sh
+dolrecomp.exe -j14 path\to\main.dol SUKE01 build
+
+./dolrecomp -j14 path/to/main.dol SUKE01 build
+```
+
+### REL Modules
 
 REL modules can be compiled one at a time or as a folder. Folder mode finds `.rel` files recursively, assigns stable virtual bases, and resolves imports between modules in that folder:
 
 ```sh
+# Windows
 dolrecomp.exe path\to\module.rel SUKE01 build
 dolrecomp.exe path\to\rel_folder SUKE01 build
 dolrecomp.exe --gamecube path\to\rel_folder build
+
+# MacOS/Linux
+./dolrecomp path/to/module.rel SUKE01 build
+./dolrecomp path/to/rel_folder SUKE01 build
+./dolrecomp --gamecube path/to/rel_folder build
 ```
 
 Use `--rel-base 0x80500000` only when you need to override the first auto-assigned REL address. REL support applies self-relocations, and imports between modules compiled together.
 
+### Wii U
 Wii U uses the Espresso CPU profile and takes an RPX:
 
 ```sh
+# Windows
 dolrecomp.exe --cpu espresso path\to\main.rpx build
-```
 
+# MacOS/Linux
+./dolrecomp --cpu espresso path/to/main.rpx build
+```
 
 You cannot specify --gamecube while using espresso.
 
+### Additional Info
 
 Disc extraction is available as a subcommand for future installer work. It accepts `.iso` and `.wbfs` only:
 
 ```sh
+# Windows
 dolrecomp.exe extract game.iso extracted
 dolrecomp.exe extract game.wbfs extracted
+
+# MacOS/Linux
+./dolrecomp extract game.iso extracted
+./dolrecomp extract game.wbfs extracted
 ```
 
 GameCube ISO extraction is built in. Wii ISO/WBFS extraction uses Wiimms ISO Tool (`wit`) when needed. Run `dolrecomp.exe --setup` to install a local copy, or pass a path manually:
 
 ```sh
-dolrecomp.exe extract --wit C:\tools\wit\wit.exe game.wbfs extracted
+# Windows
+dolrecomp.exe extract --wit C:\path\to\wit.exe game.wbfs extracted
+
+# MacOS/Linux
+./dolrecomp extract --wit ./path/to/wit game.wbfs extracted
 ```
 
 Output rules:
 
 - If the last argument ends in `.c`, that exact split-output manifest is used.
-- If the last argument is a directory, Wii output goes under `<title-id>_generated\`.
-- GameCube and Wii U directory output goes under `generated\`.
+- If the last argument is a directory, Wii output goes under `<title-id>_generated` folder.
+- GameCube and Wii U directory output goes under `generated` folder.
 - `-jN` controls how many worker jobs write split C chunks.
-- If `database\titles.txt` is missing during Wii mode, DolRecomp prints a warning and uses GameCube mode.
+- If `database/titles.txt` is missing during Wii mode, DolRecomp prints a warning and uses GameCube mode.
 
 ## CPU Coverage
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,7 @@ tools/          optional developer utilities
 
 ## Contribution
 
-Check the `CONTRIBUTING.md` page. 
-
-`CONTRIBUTORS.md` includes details about contributors using `@all-contributors` bot.
+Forks are welcome. Contribution will not be accepted at the very moment, because this codebase changes rapidly.
 
 # Notices
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ devkitPro is highly recommended for Wii U recomps.
 
 ## Usage
 
+For help run
+
+```sh
+# Windows
+dolrecomp.exe
+
+# MacOS/Linux
+./dolrecomp
+```
+
+to output a list of commands and arguments.
+
 Set up the local title database if you want Wii title names in CLI output. Setup also offers to download Wiimms ISO Tools if `wit` is missing:
 
 <sub>this was just a fun extra thing, just run in gamecube mode if you want to skip it</sub>

--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ tools/          optional developer utilities
 
 ## Contribution
 
-Forks are welcome. Contribution will not be accepted at the very moment, because this codebase changes rapidly.
+Check the `CONTRIBUTING.md` page. 
+
+`CONTRIBUTORS.md` includes details about contributors using `@all-contributors` bot.
 
 # Notices
 

--- a/src/app/cli.c
+++ b/src/app/cli.c
@@ -8,7 +8,7 @@
 void print_usage(const char* argv0) {
     (void)argv0;
 
-    const char* prog = argv0 ? argv0 : "dolrecomp";
+    const char* prog = "dolrecomp.exe";
 
     fprintf(stderr, "Usage: %s [options] <input> [wii-title-id] [output.c | output-dir]\n", prog);
     fprintf(stderr, "\n");

--- a/src/app/cli.c
+++ b/src/app/cli.c
@@ -8,21 +8,35 @@
 void print_usage(const char* argv0) {
     (void)argv0;
 
-    fprintf(stderr, "usage: dolrecomp.exe [-jN] [--cpu gekko|broadway|espresso] [--gamecube] <input> [wii-title-id] [output.c | output-dir]\n");
+    const char* prog = (argv0 && *argv0) ? argv0 :
+#ifdef _WIN32
+        "dolrecomp.exe";
+#else
+        "./dolrecomp";
+#endif
+
+    fprintf(stderr, "Usage: %s [options] <input> [wii-title-id] [output.c | output-dir]\n", prog);
     fprintf(stderr, "\n");
-    fprintf(stderr, "extract:  dolrecomp.exe extract game.iso output_folder\n");
-    fprintf(stderr, "extract:  dolrecomp.exe extract game.wbfs output_folder\n");
-    fprintf(stderr, "wii:      dolrecomp.exe <input.dol> SUKE01 build\n");
-    fprintf(stderr, "gamecube: dolrecomp.exe --gamecube <input.dol> build\n");
-    fprintf(stderr, "rel:      dolrecomp.exe <input.rel | rel_folder> SUKE01 build\n");
-    fprintf(stderr, "wii u cpu: dolrecomp.exe --cpu espresso <input.rpx> build\n");
-    fprintf(stderr, "with output.c: writes that split C set\n");
-    fprintf(stderr, "with output-dir: writes output-dir/<wii-title-id>_generated/<wii-title-id>.c\n");
-    fprintf(stderr, "with --gamecube or --cpu espresso output-dir: writes output-dir/generated/generated.c\n");
-    fprintf(stderr, "-jN writes split C files with N jobs, like -j14\n");
-    fprintf(stderr, "--rel-base optionally sets the first virtual load address used for REL codegen\n");
-    fprintf(stderr, "--setup downloads database/titles.txt and can install wit tools\n");
-    fprintf(stderr, "without output: writes generated code under the current directory\n");
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "  -jN                            Use N worker jobs for split C output (e.g. -j14)\n");
+    fprintf(stderr, "  --cpu gekko|broadway|espresso  Select CPU profile (default: broadway)\n");
+    fprintf(stderr, "  --gamecube                     GameCube mode (no title ID required)\n");
+    fprintf(stderr, "  --rel-base <addr>              Override first virtual load address for REL codegen\n");
+    fprintf(stderr, "  --setup                        Download titles database and optionally install wit\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Examples:\n");
+    fprintf(stderr, "  GameCube:     %s --gamecube <input.dol> build\n", prog);
+    fprintf(stderr, "  Wii DOL:      %s <input.dol> SUKE01 build\n", prog);
+    fprintf(stderr, "  REL module:   %s <input.rel | rel_folder> SUKE01 build\n", prog);
+    fprintf(stderr, "  Wii U RPX:    %s --cpu espresso <input.rpx> build\n", prog);
+    fprintf(stderr, "  Extract ISO:  %s extract game.iso output_folder\n", prog);
+    fprintf(stderr, "  Extract WBFS: %s extract game.wbfs output_folder\n", prog);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Output rules:\n");
+    fprintf(stderr, "  output.c      Writes that exact split C set\n");
+    fprintf(stderr, "  output-dir    Wii: writes output-dir/<title-id>_generated/<title-id>.c\n");
+    fprintf(stderr, "                GameCube/Wii U: writes output-dir/generated/generated.c\n");
+    fprintf(stderr, "  (none)        Writes generated code under the current directory\n");
 }
 
 int is_title_id(const char* text) {
@@ -266,4 +280,3 @@ int parse_cli(int argc, char** argv, CliOptions* opts) {
 
     return 1;
 }
-

--- a/src/app/cli.c
+++ b/src/app/cli.c
@@ -8,12 +8,7 @@
 void print_usage(const char* argv0) {
     (void)argv0;
 
-    const char* prog = (argv0 && *argv0) ? argv0 :
-#ifdef _WIN32
-        "dolrecomp.exe";
-#else
-        "./dolrecomp";
-#endif
+    const char* prog = argv0 ? argv0 : "dolrecomp";
 
     fprintf(stderr, "Usage: %s [options] <input> [wii-title-id] [output.c | output-dir]\n", prog);
     fprintf(stderr, "\n");


### PR DESCRIPTION
Doing some cleanup after working on the documentation on the GitHub wiki page. Let me know if there is anything that you would like changed, especially after the details for contributing from [PR5](https://github.com/ExpansionPak/DolRecomp/pull/6) are merged in.

Changes:
- Included `*_generated` in `.gitignore` as this is the default output structure for Wii Dol generation, and it wasn't included.
- Included MacOS/Linux commands in `README.md`.
- Removed -j usage in commands in `README.md` as there were lots of hardcoding, and it is an additional operation that isn't necessary for the operation of generating. 
- Cleaned up the CLI, help message with command details, and made the output more separated and clear. It will ensure the printout depends on the call method of the OS. With the youth of this project, I'm still not 100% about coding safety requirements, and I haven't seen an example of how argv[0] is handled in any project, so I'm keeping a check on it. Can I know what the opinion is on this? Just simplify to a direct assignment?

Additional things:
- Currently, the tools folder seems a bit unnecessary, and even if it expands, I feel as though it would be better to include all forms of documentation in the clearly differentiated wiki page. So should I delete it?
- In `src/app/database.c`, function `print_database_missing_notice` uses `dolrecomp`
- In `src/frontend/container/disc_extract.c` function `extract_with_wit` uses `dolrecomp.exe`
- Maybe set up argv[0] in CLI to be passed? Or just set to read dolrecomp as standard?