### PR TITLE
Register only the LLVM targets this build can emit for, and build the bench on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,16 +135,26 @@ if(DOLRECOMP_ENABLE_LLVM)
         MC
         native
         nativecodegen
-        # Specific target backends required by target.cpp
-        X86CodeGen
-        X86AsmParser
-        AArch64CodeGen
-        AArch64AsmParser
-        ARMCodeGen
-        ARMAsmParser
-        RISCVCodeGen
-        RISCVAsmParser
+        # Target backends are appended below, gated on what this LLVM ships.
     )
+
+    # target.cpp registers only the targets it can emit for, and only those
+    # this LLVM was built with. Naming them unconditionally breaks two ways:
+    # against an LLVM without one of them the call does not even compile, and
+    # registering every target via InitializeAll* drags unused backends into
+    # the link. LLVM_TARGETS_TO_BUILD is what LLVMConfig.cmake reports.
+    if("X86" IN_LIST LLVM_TARGETS_TO_BUILD)
+        list(APPEND DOLRECOMP_LLVM_COMPONENTS X86CodeGen X86AsmParser)
+        target_compile_definitions(dr_llvm PRIVATE DOLLLVM_HAVE_X86_TARGET=1)
+    endif()
+    if("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
+        list(APPEND DOLRECOMP_LLVM_COMPONENTS AArch64CodeGen AArch64AsmParser)
+        target_compile_definitions(dr_llvm PRIVATE DOLLLVM_HAVE_AARCH64_TARGET=1)
+    endif()
+    if(NOT "X86" IN_LIST LLVM_TARGETS_TO_BUILD AND NOT "AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
+        message(FATAL_ERROR
+            "DolRecomp's LLVM backend needs the X86 or AArch64 target; this LLVM has: ${LLVM_TARGETS_TO_BUILD}")
+    endif()
 
     if(TARGET LLVM)
         target_link_libraries(dr_llvm PRIVATE LLVM)

--- a/benchmarks/llvm_backend_bench.c
+++ b/benchmarks/llvm_backend_bench.c
@@ -5,6 +5,10 @@
 #include <string.h>
 #include <time.h>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 void func_80003100(CPUState *cpu);
 void func_80003500(CPUState *cpu);
 void func_80003750(CPUState *cpu);
@@ -33,9 +37,17 @@ static bool region_query(CPUState *cpu, u32 address) {
 }
 
 static double seconds(void) {
+#if defined(_WIN32)
+  LARGE_INTEGER frequency;
+  LARGE_INTEGER now;
+  QueryPerformanceFrequency(&frequency);
+  QueryPerformanceCounter(&now);
+  return (double)now.QuadPart / (double)frequency.QuadPart;
+#else
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC, &now);
   return (double)now.tv_sec + (double)now.tv_nsec * 1e-9;
+#endif
 }
 
 static void prepare(CPUState *cpu, u32 pc) {

--- a/src/backend/llvm/target.cpp
+++ b/src/backend/llvm/target.cpp
@@ -45,11 +45,26 @@ static const ProfileDefinition *definition(DolLLVMTargetProfile id) {
 
 void initializeTargets() {
   static const bool once = [] {
-    InitializeAllTargetInfos();
-    InitializeAllTargets();
-    InitializeAllTargetMCs();
-    InitializeAllAsmPrinters();
-    InitializeAllAsmParsers();
+    // Only the targets DolRecomp can emit, and only those the host LLVM
+    // actually ships. InitializeAll* expands to every target this LLVM was
+    // configured with, which forces the link to carry backends the emitter
+    // never uses; naming X86 and AArch64 unconditionally instead would fail to
+    // compile against an LLVM built without one of them. CMake derives these
+    // two macros from LLVM_TARGETS_TO_BUILD, so this tracks the host build.
+#if defined(DOLLLVM_HAVE_X86_TARGET)
+    LLVMInitializeX86TargetInfo();
+    LLVMInitializeX86Target();
+    LLVMInitializeX86TargetMC();
+    LLVMInitializeX86AsmPrinter();
+    LLVMInitializeX86AsmParser();
+#endif
+#if defined(DOLLLVM_HAVE_AARCH64_TARGET)
+    LLVMInitializeAArch64TargetInfo();
+    LLVMInitializeAArch64Target();
+    LLVMInitializeAArch64TargetMC();
+    LLVMInitializeAArch64AsmPrinter();
+    LLVMInitializeAArch64AsmParser();
+#endif
     return true;
   }();
   (void)once;


### PR DESCRIPTION
## What

`main` does not link against the official LLVM 20 Windows package.

`target.cpp` calls `InitializeAll*`, which expands to every target the host LLVM was configured with. That package ships seven (`AArch64 ARM X86 BPF WebAssembly RISCV NVPTX`) while `CMakeLists.txt` linked four, so the link fails with 14 unresolved `LLVMInitialize*` symbols for BPF, WebAssembly and NVPTX.

## Why this shape

Naming X86 and AArch64 unconditionally fixes Windows but breaks against an LLVM built without one of them — the call would not even compile. So both the registration and the linked component list are derived from `LLVM_TARGETS_TO_BUILD`, which `LLVMConfig.cmake` reports:

```cmake
if("X86" IN_LIST LLVM_TARGETS_TO_BUILD)
    list(APPEND DOLRECOMP_LLVM_COMPONENTS X86CodeGen X86AsmParser)
    target_compile_definitions(dr_llvm PRIVATE DOLLLVM_HAVE_X86_TARGET=1)
endif()
```

with matching `#if defined(...)` guards in `target.cpp`, and a `FATAL_ERROR` if neither target is present.

## Also

`benchmarks/llvm_backend_bench.c` used `clock_gettime`/`CLOCK_MONOTONIC`, which MSVC does not provide, so the benchmark target never built on Windows. Adds a `QueryPerformanceCounter` path; the POSIX path is unchanged.

## Verification

- 28/28 ctest on Windows (MSVC 19.50, LLVM 20.1.8 — 7 targets)
- 28/28 ctest on a Raspberry Pi 4 (GCC 14.2, LLVM 19 — 21 targets)

Those two LLVM builds have very different target sets, which is what exercises the gating in both directions.