### PR TITLE
Add --state-in-memory: keep the guest register file out of SSA

### DIFF
--- a/src/app/cli.c
+++ b/src/app/cli.c
@@ -16,6 +16,8 @@ void print_usage(const char* argv0) {
     fprintf(stderr, "  -jN                            Use N worker jobs for split C output (e.g. -j14)\n");
     fprintf(stderr, "  --cpu gekko|broadway|espresso  Select CPU profile (default: broadway)\n");
     fprintf(stderr, "  --backend c|llvm               Select generated-code backend (default: c)\n");
+    fprintf(stderr, "  --state-in-memory              Keep guest state in CPUState instead of\n");
+    fprintf(stderr, "                                 hoisting it into promoted allocas\n");
     fprintf(stderr, "  --targets <set>                host, x86-64-v2, x86-64-v3, aarch64, aarch64-a57\n");
     fprintf(stderr, "  --semantics exact|fast         PowerPC floating-point semantics (default: exact)\n");
     fprintf(stderr, "  --instrumentation none|lockstep  Compile release or state-journal objects\n");
@@ -189,6 +191,14 @@ int parse_cli(int argc, char** argv, CliOptions* opts) {
 
         if (strcmp(arg, "--gamecube") == 0 || strcmp(arg, "-gc") == 0) {
             opts->gamecube_mode = 1;
+            continue;
+        }
+        if (strcmp(arg, "--state-in-memory") == 0) {
+            opts->state_in_memory = 1;
+            continue;
+        }
+        if (strcmp(arg, "--no-state-in-memory") == 0) {
+            opts->state_in_memory = 0;
             continue;
         }
 

--- a/src/app/cli.h
+++ b/src/app/cli.h
@@ -30,6 +30,7 @@ typedef struct {
     int setup_mode;
     int show_help;
     int fast_semantics;
+    int state_in_memory;
     int lockstep_instrumentation;
 } CliOptions;
 

--- a/src/app/pipeline.c
+++ b/src/app/pipeline.c
@@ -73,6 +73,7 @@ typedef struct {
     const char* profile_generate_path;
     const char* profile_use_path;
     u64 partition_seed;
+    int state_in_memory;
     u32 ram_size;
     u32 mem2_size;
     char symbol_suffix[32];
@@ -260,6 +261,11 @@ static u64 llvm_job_hash(const LLVMChunkJob* job) {
     hash = hash_bytes(hash, &job->semantics, sizeof(job->semantics));
     hash = hash_bytes(hash, &job->instrumentation,
                       sizeof(job->instrumentation));
+    /* Changes the emitted code, so a plan built with it must not collide with
+       one built without it. Omitting this is how a toggled codegen option
+       silently returns another configuration's objects. */
+    hash = hash_bytes(hash, &job->state_in_memory,
+                      sizeof(job->state_in_memory));
     hash = hash_bytes(hash, &job->partition_seed,
                       sizeof(job->partition_seed));
     hash = hash_bytes(hash, &job->ram_size, sizeof(job->ram_size));
@@ -465,6 +471,7 @@ static int emit_llvm_chunk_job(const void* data, void* user) {
     options.profile_generate_path = job->profile_generate_path;
     options.profile_use_path = job->profile_use_path;
     options.partition_seed = job->partition_seed;
+    options.state_in_memory = job->state_in_memory;
     options.emit_thinlto = 1;
     options.thinlto_path = job->thinlto_path;
     options.fixed_memory_layout = 1;
@@ -880,6 +887,7 @@ static int emit_code_sections_llvm(const LoadedCodeSection* sections,
                     options->profile_generate_path;
                 target_job->profile_use_path = options->profile_use_path;
                 target_job->partition_seed = options->partition_seed;
+                target_job->state_in_memory = options->state_in_memory;
                 target_job->ram_size = GC_MAIN_RAM_SIZE;
                 target_job->mem2_size = cpu == DOLRECOMP_CPU_GEKKO
                                              ? 0u

--- a/src/backend/llvm/branch_targets.cpp
+++ b/src/backend/llvm/branch_targets.cpp
@@ -93,6 +93,8 @@ BasicBlock *FunctionEmitter::externalDestination(const DolIRTerminator &term,
       if (!used_[state])
         continue;
       auto stateSlot = static_cast<DolIRStateSlot>(state);
+      if (slotInMemory(stateSlot))
+        continue;
       builder_.CreateStore(loadContext(stateSlot), state_[state]);
     }
     builder_.CreateBr(blocks_[continuationBlock]);

--- a/src/backend/llvm/emitter.cpp
+++ b/src/backend/llvm/emitter.cpp
@@ -29,6 +29,7 @@ FunctionEmitter::FunctionEmitter(LLVMContext &context, Module &module,
       semantics_(options.semantics),
       symbol_suffix_(options.symbol_suffix ? options.symbol_suffix : ""),
       fixed_memory_layout_(options.fixed_memory_layout != 0),
+      state_in_memory_(options.state_in_memory != 0),
       expected_ram_size_(options.ram_size),
       expected_mem2_size_(options.mem2_size) {}
 

--- a/src/backend/llvm/emitter.h
+++ b/src/backend/llvm/emitter.h
@@ -65,6 +65,10 @@ private:
   void scanLoopHeaders();
   void scanRegionLeaders();
   void finalizeStateSSA();
+  bool stateInMemory() const;
+  bool state_in_memory_ = false;
+  static bool slotIsPacked(DolIRStateSlot slot);
+  bool slotInMemory(DolIRStateSlot slot) const;
 
   void emitEntry();
   bool emitWrapper(llvm::raw_ostream &diagnostics);
@@ -190,7 +194,11 @@ private:
   llvm::Value *mem2_size_ = nullptr;
   llvm::BasicBlock *fallback_block_ = nullptr;
   llvm::PHINode *fallback_pc_ = nullptr;
-  std::array<llvm::AllocaInst *, DOLIR_STATE_COUNT> state_{};
+  // Where each guest state slot lives in this function. By default an alloca
+  // that mem2reg promotes; with --state-in-memory a pointer straight into
+  // CPUState, so every load and store site works unchanged either way. Packed
+  // slots always keep an alloca -- they have no standalone storage to point at.
+  std::array<llvm::Value *, DOLIR_STATE_COUNT> state_{};
   std::array<llvm::AllocaInst *, 32> pair_f32_{};
   std::array<llvm::AllocaInst *, 32> pair_f64_{};
   std::array<FPRepresentation, 32> fp_rep_{};

--- a/src/backend/llvm/exits.cpp
+++ b/src/backend/llvm/exits.cpp
@@ -27,6 +27,12 @@ void FunctionEmitter::emitEntry() {
     if (!used_[slot])
       continue;
     auto stateSlot = static_cast<DolIRStateSlot>(slot);
+    if (slotInMemory(stateSlot)) {
+      // No alloca and no entry copy: the slot is read and written where it
+      // already lives, inside CPUState.
+      state_[slot] = bytePtr(stateOffset(stateSlot));
+      continue;
+    }
     state_[slot] = builder_.CreateAlloca(type(dolir_state_type(stateSlot)),
                                          nullptr, "state");
   }
@@ -97,6 +103,9 @@ void FunctionEmitter::emitEntry() {
     if (!used_[slot])
       continue;
     auto stateSlot = static_cast<DolIRStateSlot>(slot);
+    // A slot that already points into CPUState needs no prologue copy.
+    if (slotInMemory(stateSlot))
+      continue;
     builder_.CreateStore(loadContext(stateSlot), state_[slot]);
   }
   initializeEntryControls();
@@ -132,6 +141,10 @@ void FunctionEmitter::syncDirtyState() {
     if (!dirty_[slot] || slot == DOLIR_STATE_FPSCR)
       continue;
     auto stateSlot = static_cast<DolIRStateSlot>(slot);
+    // Nothing was hoisted for this slot, so nothing has gone stale; the load
+    // would read a CPUState field and store it straight back to itself.
+    if (slotInMemory(stateSlot))
+      continue;
     storeContext(
         stateSlot,
         builder_.CreateLoad(type(dolir_state_type(stateSlot)), state_[slot]));

--- a/src/backend/llvm/llvm_backend.h
+++ b/src/backend/llvm/llvm_backend.h
@@ -48,6 +48,10 @@ typedef struct {
     u32 ram_size;
     u32 mem2_size;
     u64 partition_seed;
+    /* Keep guest state in CPUState instead of hoisting it into allocas that
+       mem2reg promotes. Changes emitted code, so it participates in the object
+       cache key. */
+    int state_in_memory;
     const DolLLVMFunctionRange* function_ranges;
     u32 function_range_count;
     const u32* entry_points;

--- a/src/backend/llvm/register_state.cpp
+++ b/src/backend/llvm/register_state.cpp
@@ -10,11 +10,43 @@ namespace dolllvm {
 
 using namespace llvm;
 
+// Guest state can live in CPUState instead of being hoisted into allocas at
+// region entry.
+//
+// Promoting the guest register file gives the register allocator far more
+// simultaneously live values than x86-64 has registers, so it spills them
+// straight back. Measured on GM4E01: 631 state phi nodes across 228 basic
+// blocks in a single chunk, 20+ per block in hot loops. AArch64's 31 GPRs
+// absorb much of that; x86-64's 16 do not.
+//
+// Note that skipping PromoteMemToReg alone achieves nothing: optimizeModule()
+// runs the standard -O2 pipeline before emission and SROA/mem2reg promote the
+// allocas anyway. The allocas have to not exist.
+bool FunctionEmitter::stateInMemory() const { return state_in_memory_; }
+
+// These slots are bitfields inside a wider CPUState word rather than
+// addressable storage: CR0-CR7 are nibbles of cr, XER_CA-XER_SO are bits of
+// xer, and XER itself preserves those flag bits while writing only the low 29.
+// storeContext and loadContext pack and unpack them, so they cannot be pointed
+// at directly and always keep an alloca.
+bool FunctionEmitter::slotIsPacked(DolIRStateSlot slot) {
+  return (slot >= DOLIR_STATE_CR0 && slot <= DOLIR_STATE_CR7) ||
+         (slot >= DOLIR_STATE_XER_CA && slot <= DOLIR_STATE_XER_SO) ||
+         slot == DOLIR_STATE_XER;
+}
+
+bool FunctionEmitter::slotInMemory(DolIRStateSlot slot) const {
+  return stateInMemory() && !slotIsPacked(slot);
+}
+
 void FunctionEmitter::finalizeStateSSA() {
+  // Nothing was hoisted, so there is nothing to promote.
+  if (stateInMemory())
+    return;
   SmallVector<AllocaInst *, DOLIR_STATE_COUNT + 64> registers;
-  for (AllocaInst *slot : state_)
-    if (slot)
-      registers.push_back(slot);
+  for (Value *slot : state_)
+    if (auto *alloca = dyn_cast_or_null<AllocaInst>(slot))
+      registers.push_back(alloca);
   for (AllocaInst *pair : pair_f32_)
     if (pair)
       registers.push_back(pair);

--- a/src/backend/llvm/runtime.cpp
+++ b/src/backend/llvm/runtime.cpp
@@ -32,6 +32,10 @@ void FunctionEmitter::reloadState(DolIRStateSlot slot) {
   known_state_[slot] = nullptr;
   if (slot == DOLIR_STATE_FPSCR)
     pending_fprf_ = nullptr;
+  // The helper wrote CPUState directly and the slot points there, so the value
+  // is already current; only the cached constant needed clearing.
+  if (slotInMemory(slot))
+    return;
   builder_.CreateStore(loadContext(slot), state_[slot]);
 }
 


### PR DESCRIPTION
The LLVM backend loads every state slot a region touches into an alloca at entry and lets mem2reg promote it. That is the textbook move, and on this workload it loses to the C backend.

## Why promotion backfires here

Promoting a whole guest register file gives the allocator far more simultaneously live values than the machine has registers, so it spills them straight back. Measured on GM4E01, one boot chunk carries **631 state phi nodes across 228 basic blocks**, 20+ per block in hot loops:

```llvm
%state106.0 = phi i32 [ %186, %fallback_repeat_check ], [ %85, ... ]
%state105.0 = phi i32 [ %185, %fallback_repeat_check ], [ %84, ... ]
%state103.0 = phi i32 [ %183, %fallback_repeat_check ], [ %82, ... ]
...
```

x86-64 has 16 GPRs. The live set is many times that, so the result is phi construction, a much larger function and worse allocation — arriving back at values in memory, with more instructions around them. The C backend never had this problem because generated C operates directly on `ctx->gpr[N]` and clang hoists only what pays, locally.

## The change

`--state-in-memory` points `state_[slot]` straight into `CPUState`. Every load and store site works unchanged; what disappears is the entry prologue and, with it, the materialization barriers — those exist only to flush values that were hoisted, and nothing is hoisted.

Same chunk, with the option on: **0 state phis**, `getelementptr` straight off `ctx`. LLVM still forwards stores to loads and keeps values in registers where that pays; it is simply no longer forced to keep the entire register file live across a region.

## Measurements

Same DOL per title, same module compiler (clang 20.1.8, `-O2 -flto=thin`), `bench-interleaved` 6 forward + 6 reversed pairs, machine idle, no build overlapping a measurement. `speed` is the guest clock ratio; `fps` is the median present rate over the sample window.

### With `--state-in-memory`, against the C backend

| platform | title / scene | C speed / fps | arm speed / fps | ratio | pairs | vs current LLVM |
|---|---|---|---|---|---|---|
| x86-64 | GM4E01 `race.sav` | 1.0597 / 63.53 | **1.3208 / 79.10** | **1.2464** | 12/12 | 1.46x |
| x86-64 | GLME01 `foyer.sav` | 1.7026 / 50.57 | **1.9482 / 58.03** | **1.1442** | 12/12 | 1.37x |
| x86-64 | SOUE01 `gameplay.sav` | 1.6724 / 49.71 | **1.8620 / 55.56** | **1.1134** | 12/12 | 1.57x |
| AArch64 Pi 4 | GLME01 cold boot | 0.1920 / 5.27 | **0.2490 / 6.98** | **1.3035** | 6/6 | — |

Every measurable title, every pair. All are ratios against the C backend, measured directly rather than chained. On AArch64 the same option measures **1.1327** against the unmodified LLVM backend (6/6 pairs), so the win is not an artefact of the C control.

Module size falls on every title:

| title | before | after |
|---|---|---|
| GM4E01 | 389.1 MB | 161.0 MB |
| GLME01 | 204.9 MB | 91.9 MB |
| SOUE01 | 548.0 MB | 221.8 MB |
| GLME01 (AArch64) | 126.0 MB | 78.7 MB |

The gain is larger on x86-64 than on AArch64, which is what the register-pressure explanation predicts: AArch64's 31 GPRs already absorb much of the promoted live set — which is also why the LLVM backend was already ahead of C there and behind it on x86-64. The asymmetry is the mechanism showing through.

### Backend landscape across the whole test set, x86-64

Context for where the backend sits per title. These arms are the existing backend and two configurations of the AOT branch (#16).

| title | arm | speed | fps | ratio vs C | pairs |
|---|---|---|---|---|---|
| GM4E01 Mario Kart | C control | 1.0411 | 62.37 | 1.0000 | — |
| | LLVM (pre-rewrite) | 0.5441 | 32.50 | 0.4990 | 0/12 |
| | LLVM (current) | 0.8793 | 52.67 | 0.8533 | 0/12 |
| | AOT branch, fixed-chunk | 1.1459 | 68.69 | 1.1007 | 10/12 |
| | AOT branch, region | 1.1243 | 67.67 | 1.1181 | 11/12 |
| | **`--state-in-memory`** | **1.3208** | **79.10** | **1.2464** | **12/12** |
| GLME01 Luigi's Mansion | C control | 1.6660 | 49.44 | 1.0000 | — |
| | LLVM (pre-rewrite) | 1.0017 | 29.64 | 0.5800 | 0/12 |
| | LLVM (current) | 1.4516 | 43.13 | 0.8330 | 0/12 |
| | AOT branch, region | 1.7388 | 51.79 | 1.0437 | 10/12 |
| | **`--state-in-memory`** | **1.9482** | **58.03** | **1.1442** | **12/12** |
| SOUE01 Skyward Sword | C control | 1.6724 | 49.71 | 1.0000 | — |
| | LLVM (current) | 1.1481 | 33.94 | 0.7110 | 1/12 |
| | AOT branch | does not render | — | — | — |
| | **`--state-in-memory`** | **1.8620** | **55.56** | **1.1134** | **12/12** |
| GC6E01 Colosseum | C control | — | 54.67 | — | — |
| | all LLVM backends | — | 0.34–0.85 | not measurable | — |

Two titles do not yield a usable LLVM number, and neither is affected by this change:

- **SOUE01 Skyward Sword** renders under the current LLVM backend (0.7110) and under this change (1.1134), but not under the pre-rewrite backend or the AOT branch — both advance `frame_count` to an identical 17684 while presenting exactly 1 frame.
- **GC6E01 Colosseum** does not render under *any* LLVM backend, on x86-64 or AArch64, at cold boot or from a savestate, including on freshly extracted retail disc data. The guest runs at full speed with the video interrupt ticking normally while `frame_count` stays frozen. Worth flagging for anyone benchmarking that title: `speed` counts retired guest cycles, so a non-rendering module *rewards* itself on that metric — on speed alone it reads as a 3.58x win over C. fps and sample count are what expose it.

An Apple Silicon run is in progress and will follow as a comment.

## Correctness detail

Three slot families keep their allocas. `CR0..CR7` are 4-bit nibbles of `CPUState.cr`, `XER_CA..XER_SO` are individual bits of `xer`, and `XER` itself writes only the low 29 bits while preserving the flag bits. `storeContext`/`loadContext` pack and unpack them, so they have no standalone storage to point at. Pointing them at raw addresses corrupts `CPUState` — it produced `Invalid read from 0x00000010` and a green screen at 0 fps. `slotIsPacked()` keeps them on the promoted path.

## Cache key

The option participates in the object cache key. It changes emitted code, so an entry built with it must not collide with one built without it. Without that, toggling the flag returns the other configuration's objects and you end up benchmarking a module against itself — the emitter never runs, so nothing looks wrong.

## Notes

Off by default.

Skipping the `PromoteMemToReg` call alone achieves nothing: `optimizeModule()` runs the standard `-O2` pipeline before emission and SROA/mem2reg promote the allocas anyway. Verified byte-identical IR either way. The allocas have to not exist.

Tests: 26/28 pass. `codegen_compile` and `llvm_generated_compile` fail identically on an unmodified build in this environment (`rc.exe` not on PATH in the nested build), so they are not related to this change.

Build notes, both environmental rather than code dependencies of this change:

- Linking against an LLVM built without BPF/WebAssembly/NVPTX needs #17, which gates target registration on what the build can actually emit for. An LLVM with all targets enabled links `main` as-is.
- Emitting SOUE01 at all needs #18. Without it all 9917 objects emit and the verifier then rejects the module with `PHINode should have one entry for each predecessor of its parent basic block!` on `%fallback_pc` — the defect #18 fixes. The SOUE01 row above was measured with #18 merged.
