### PR TITLE
Invalidate emitter state caches where they can go stale

### DIFF
--- a/src/backend/llvm/branch_targets.cpp
+++ b/src/backend/llvm/branch_targets.cpp
@@ -89,12 +89,15 @@ BasicBlock *FunctionEmitter::externalDestination(const DolIRTerminator &term,
     builder_.CreateRetVoid();
   } else {
     reloadCallCounters();
-    for (u32 state = 0; state < DOLIR_STATE_COUNT; state++) {
-      if (!used_[state])
-        continue;
-      auto stateSlot = static_cast<DolIRStateSlot>(state);
-      builder_.CreateStore(loadContext(stateSlot), state_[state]);
-    }
+    // The callee can invalidate anything the emitter had concluded about
+    // guest state: whether MSR[FP] was already checked, which slots hold
+    // known constants, whether paired-single addressing was proven.
+    // Reloading the values without dropping those conclusions leaves
+    // stateValue() returning a constant the callee has since overwritten.
+    // The fallback resume path already uses reloadUsedState() for exactly
+    // this reason; this path reloaded values by hand and skipped the
+    // invalidation.
+    reloadUsedState();
     builder_.CreateBr(blocks_[continuationBlock]);
   }
   builder_.restoreIP(saved);

--- a/src/backend/llvm/register_state.cpp
+++ b/src/backend/llvm/register_state.cpp
@@ -58,6 +58,15 @@ void FunctionEmitter::noteStateWrite(DolIRStateSlot slot, Value *value) {
   } else if (slot == DOLIR_STATE_HID2) {
     psq_direct_proven_ = false;
     psq_indexed_proven_ = false;
+  } else if (slot == DOLIR_STATE_MSR) {
+    // MSR[FP] decides whether a floating-point instruction traps, and
+    // emitFPAvailable caches that answer for the rest of the region. A
+    // write to MSR can clear FP, so the cached answer has to go. Without
+    // this an mtmsr that disables FP mid-region leaves the FP
+    // instructions after it running unchecked, and the guest never takes
+    // the FP-unavailable exception its lazy FPU context switching is
+    // built on.
+    fp_available_checked_ = false;
   }
 }
 


### PR DESCRIPTION
`emitFPAvailable` checks `MSR[FP]` once and caches the answer for the rest of the region, so floating-point instructions after the first one skip the check. That is sound only while `MSR` cannot change underneath it — and `noteStateWrite` does not clear the cache on an `MSR` write.

So a region shaped like this:

```
fadd    f1, f2, f3      ; checks MSR[FP], caches "available"
mtmsr   r0              ; clears MSR[FP]
fadd    f4, f5, f6      ; skips the check, executes anyway
```

runs the second `fadd` with floating point disabled and raises no FP-unavailable exception. The guest's lazy FPU context switching is built on receiving that exception, so a thread that should have had its FPU context saved silently does not.

`noteStateWrite` already invalidates the related caches for `FPR`, `PS1`, `FPSCR` and `HID2` writes — `MSR` was the missing case:

```cpp
} else if (slot == DOLIR_STATE_HID2) {
    psq_direct_proven_ = false;
    psq_indexed_proven_ = false;
} else if (slot == DOLIR_STATE_MSR) {
    fp_available_checked_ = false;      // added
}
```

The C backend does not have this problem because it emits `ppc_fp_available_inline` per instruction rather than caching one answer per region.

## Honesty about impact

I found this while investigating something else, and **it is rare in practice**. An `mtmsr` and a floating-point instruction have to land in the same region for it to bite. On Pokémon Colosseum it changes exactly **one of 4890** emitted objects (`chunk_3686_text1_801CFBE0.o`), verified by hashing every object before and after.

I do not have a title whose visible behaviour changes because of it. It is offered as a correctness fix, not as a fix for a reported symptom — the code is wrong in a way that could produce silent FPU state corruption on any title where the pattern occurs, and it is cheaper to close than to diagnose later.

---

## Second commit: the same class of bug on the call-resume path

While checking whether the MSR case had siblings, the native call-resume path turned out to have the same shape. It reloads each used state slot from `CPUState` by hand, but leaves the emitter's compile-time conclusions intact — and the callee is free to invalidate every one of them:

| cache | what it asserts |
|---|---|
| `fp_available_checked_` | `MSR[FP]` was already checked this region |
| `known_state_` | a slot holds a known constant |
| `psq_direct_proven_` / `psq_indexed_proven_` | paired-single addressing was proven |
| FP representation tracking | how an FPR is currently represented |

`known_state_` is the sharpest of these, because `stateValue()` returns the cached constant *in preference to loading memory*. If the emitter proved a slot held a constant before the call and the callee overwrites it, the caller keeps using the stale constant — even though the reload put the correct value in memory.

`reloadUsedState()` performs the same per-slot reload and drops the caches, and the fallback resume path in `control_flow.cpp` already uses it for exactly this reason. This just makes the native-call path consistent with it.

Same honesty as above: the two fixes together change **one of 4890** emitted objects on Pokémon Colosseum. Both are correctness fixes without an observed symptom behind them.
