### PR TITLE
Do not set an ELF cold-section name on Mach-O targets

### DIFF
--- a/src/backend/llvm/fp_fixups.cpp
+++ b/src/backend/llvm/fp_fixups.cpp
@@ -5,6 +5,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/Module.h>
+#include <llvm/TargetParser/Triple.h>
 
 #include "common/types.h"
 
@@ -18,7 +19,13 @@ static void markColdFixup(Function *function) {
   function->addFnAttr(Attribute::NoInline);
   function->addFnAttr(Attribute::NoUnwind);
   function->addFnAttr(Attribute::WillReturn);
-  function->setSection(".text.unlikely." + function->getName().str());
+  // Mach-O section specifiers are "__SEGMENT,__section" and its writer rejects
+  // anything else outright, so a bare ".text.unlikely.*" name aborts emission on
+  // Darwin targets ("invalid section specifier"). ELF and COFF both accept the
+  // name, and the Cold plus NoInline attributes already carry the placement hint
+  // on every target, so dropping only the name on Mach-O costs nothing.
+  if (!Triple(function->getParent()->getTargetTriple()).isOSBinFormatMachO())
+    function->setSection(".text.unlikely." + function->getName().str());
 }
 
 Function *getPairNaNFixup(Module &module, Type *pairType) {


### PR DESCRIPTION
## Summary

Fixes #25 — the LLVM backend cannot emit a module on macOS.

`markColdFixup()` in `src/backend/llvm/fp_fixups.cpp` names the FP fixup helpers `".text.unlikely.<fn>"` unconditionally. Mach-O section specifiers must be `"__SEGMENT,__section"`, and its writer rejects anything else outright, so on Darwin targets emission aborts:

```
LLVM ERROR: Global variable 'fix_pair_nan_f64' has an invalid section specifier
'.text.unlikely.fix_pair_nan_f64': mach-o section specifier requires a segment and
section separated by a comma.
```

Building Luigi's Mansion (GLME01) for `aarch64-apple-darwin` died at chunk 57 of 4164.

## The change

Skip only the section name, and only on Mach-O. ELF and COFF both accept it and keep it, so x86-64 Windows and Linux codegen are byte-for-byte unchanged. `Attribute::Cold` and `Attribute::NoInline` still apply everywhere, so the placement hint itself is not lost — only the ELF-shaped name that Mach-O cannot parse.

## Verification

- **macOS (Apple Silicon M5, clang/LLVM 20)**: with the name suppressed, all 4164 chunks emit and the module runs correctly — Luigi's Mansion `foyer.sav`, uncapped, interleaved blocks with a discarded warm run per arm: **LLVM median 81.2 fps vs 79.1 for the C backend** on the same host, no freeze, end frames advancing normally every run.
- **Windows x86-64 (MSVC, LLVM 20)**: builds clean; the guard is false for COFF so behaviour is unchanged.

One related observation while setting the macOS side up, not addressed here: at this commit the C backend emits calls to `ppc_fp_available_inline`, which does not exist in the ModernGekko GXRuntime we build against (`GXRuntime/include/core/cpu.h` declares only `ppc_fp_available`), so a same-commit C module could not be built on that checkout for comparison.
