### PR TITLE
Make the instruction after an MSR write a region leader

### DIFF
--- a/src/backend/llvm/register_state.cpp
+++ b/src/backend/llvm/register_state.cpp
@@ -151,6 +151,43 @@ void FunctionEmitter::scanRegionLeaders() {
       region_leaders_[i] = true;
     if (i + 1u < source_.block_count && term.kind != DOLIR_TERM_FALLTHROUGH)
       region_leaders_[i + 1u] = true;
+    // A block that writes MSR can return to the dispatcher and resume at the
+    // NEXT instruction, so that instruction has to be enterable. Terminators
+    // are already covered above; this catches the fallthrough case, which is
+    // mtmsr.
+    //
+    // Keyed on an MSR write rather than on MAY_EXIT generally. MAY_EXIT is
+    // carried by a large number of instructions -- the broader rule fired
+    // 160,525 times on Colosseum -- and every extra leader fragments a region,
+    // which costs optimisation. Measured: the broad rule cost plain llvm
+    // 5-16% on the three titles that never needed it, while only a handful of
+    // addresses are ever actually re-entered.
+    //
+    // Without this, re-entry lands on a non-leader address, the entry dispatch
+    // has no case for it, and the runtime interprets from there until it
+    // reaches the next leader. Colosseum calls OSRestoreInterrupts roughly
+    // every 139 guest cycles, and its last two instructions sit exactly in that
+    // gap: 166M interpreted instructions, 92% of all dispatches in that arm.
+    // The C backend never pays this because it labels every address.
+    //
+    // REQUIRES the runtime to deliver pending external interrupts at the
+    // post-mtmsr boundary. emitStateWrite side-exits to guest_pc+4 when MSR[EE]
+    // goes 0->1; before this rule the address was not enterable, so the runtime
+    // interpreted from there and delivered the interrupt as a side effect of
+    // that detour. Removing the detour without the runtime half leaves the
+    // guest spinning with EE set on an interrupt that never arrives -- Colosseum
+    // advances 19 frames in 20s instead of 1069. native_exc is the tell: 312
+    // while hung, 25,009 once delivery is restored.
+    if (i + 1u < source_.block_count) {
+      const DolIRBlock &body = source_.blocks[i];
+      for (u32 n = 0; n < body.instruction_count; n++) {
+        if (dolir_state_mask_test(body.instructions[n].state_defs,
+                                  DOLIR_STATE_MSR)) {
+          region_leaders_[i + 1u] = true;
+          break;
+        }
+      }
+    }
     u32 count = term.kind == DOLIR_TERM_COND_BRANCH ? 2u
                 : term.kind == DOLIR_TERM_BRANCH    ? 1u
                 : term.kind == DOLIR_TERM_INDIRECT  ? 2u


### PR DESCRIPTION
`emitStateWrite` side-exits to `guest_pc + 4` when `mtmsr` takes `MSR[EE]` from 0 to 1, so the dispatcher can deliver a pending external interrupt there. That address was not an entry-switch case, so the dispatch missed, fell into `emitColdEntry`, and the runtime interpreted from there until it reached the next region leader.

On Pokémon Colosseum `OSRestoreInterrupts` runs roughly every 139 guest cycles and its tail sits exactly in that gap — 140M interpreted instructions, 92% of all dispatches in that arm. The C backend never pays this because it labels every address.

### Why an MSR write rather than MAY_EXIT

`DOLIR_EFFECT_MAY_EXIT` is carried by a large number of instructions; the broad rule fires 160,525 times on Colosseum, and every extra leader fragments a region and costs optimisation. Measured, the broad rule cost the plain LLVM backend 5–16% on the three titles that never needed it. Keying on the MSR write is what makes this free elsewhere.

### Measurements

A/B against the unmodified backend — same recompiler binary, same DOL, only this rule differs. 3 pairs per scene, 15s warmup, 20s samples, forward and reversed blocks per comparison.

| Title | Mean | Min | Max | Scenes |
|---|---|---|---|---|
| Pokémon Colosseum | **1.4943** | 1.4730 | 1.5060 | 1 scene x4 runs |
| Luigi's Mansion | 1.0042 | 0.9999 | 1.0082 | 2 |
| Mario Kart: Double Dash | 0.9971 | 0.9586 | 1.0179 | 6 |
| Skyward Sword | 1.0020 | 0.9995 | 1.0065 | 2 |

The neutral titles are each the mean of two independent full campaigns, and the per-title figures reproduced across them to within 0.4%.

Colosseum is a single scene (`clean-field2`) measured four times: 1.4730, 1.4960, 1.5023, 1.5060. An earlier fifth observation of 1.95 is not included — it did not reproduce, and its arm median (1.7797) is far outside the 1.187 the four later runs agree on, so it is treated as an artefact of machine state rather than a valid measurement.

Counter evidence, which does not depend on wall-clock and is stable across all runs — Colosseum `clean-field2`, 20s:

```
             hook_fb        native_exc
llvm      147,774,885           12,735
llvm-msr       44,207           25,009
```

`hook_fb` is interpreter fallback dispatches. Frame progression over the same window goes 551 -> 1069 frames.

### Runtime dependency

This needs the runtime to deliver pending external interrupts at the post-`mtmsr` boundary. That is already on `moderngekko-vendor` (`after_mtmsr` in `StaticRecompCore_Run.cpp`), so no runtime change is required alongside this. All figures above were measured against that upstream implementation.

It does matter for anyone testing against an older runtime: the interpreter detour this removes was previously the only thing delivering the interrupt. Without the runtime half, Colosseum advances 19 frames in 20s instead of 1069, and `native_exc` reads 312 instead of 25,009.

### Checks

Lockstep against the interpreter shows no divergence beyond the unmodified control — both arms report an identical first 8 divergences and both reach the report cap, so this changes dispatch granularity, not semantics.